### PR TITLE
Fix uv install command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies (via uv)
         run: |
           uv venv
-          uv pip install -e ".[dev]"
+          uv pip install -e . --group dev
 
       - name: Run Ruff (Lint & Format Check)
         run: uv run ruff check .


### PR DESCRIPTION
## Summary
- use the same uv install syntax across docs and CI

## Testing
- `uv run pre-commit --files .github/workflows/ci.yml` *(fails: No route to host)*
- `uv run pytest` *(fails: No route to host)*