### PR TITLE
fix: configure ruff for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,17 @@ preview = true
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = ["CPY001", "D203", "D213"]
+per-file-ignores = {"tests/**" = [
+    "S101",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+]}
 
 [tool.mypy]
 python_version = "3.13"

--- a/src/project_name/app.py
+++ b/src/project_name/app.py
@@ -2,5 +2,13 @@
 
 
 def hello(name: str) -> str:
-    """Return a friendly greeting."""
+    """Return a friendly greeting.
+
+    Args:
+        name: The name to greet.
+
+    Returns:
+        The greeting message.
+
+    """
     return f"Hello, {name}!"


### PR DESCRIPTION
## Summary
- allow asserts and missing docstrings in `tests/`
- remove now-unnecessary noqa comment

## Testing
- `uv run ruff check --fix .`
- `uv run mypy .`
- `uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100`
