### PR TITLE
docs: recommend uv sync for reproducible setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
           version: "0.7.6"
 
       - name: Install dependencies (via uv)
-        run: |
-          uv venv
-          uv pip install -e . --group dev
+        run: uv sync --locked
 
       - name: Run Ruff (Lint & Format Check)
         run: uv run ruff check .
@@ -35,4 +33,4 @@ jobs:
         run: uv run mypy .
 
       - name: Run Tests (Pytest with Coverage)
-        run: uv run pytest --cov=project_name --cov-report=term --cov-fail-under=100
+        run: uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ linting and formatting. All code lives in `src/` and is tested with pytest to
 
 1. Install [uv](https://github.com/astral-sh/uv) or run `./bootstrap.sh` which
    performs all setup steps automatically.
-2. If running manually, create a virtual environment and install dependencies:
+2. If running manually, install dependencies from `uv.lock` for a fully
+   reproducible environment:
 
    ```bash
-   uv venv
-   # Install project and dev dependencies from the `dev` group
-   uv pip install -e . --group dev
+   uv sync --locked
    ```
 
 3. Run the tests:


### PR DESCRIPTION
## Summary
- sync dependencies from `uv.lock` in CI
- instruct developers to use `uv sync --locked` in the README

## Testing
- `uv run ruff check --fix .`
- `uv run mypy .`
- `uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100`
