### PR TITLE
chore: streamline pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
-    hooks:
-      - id: mypy
-        args: [--strict]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ linting and formatting. All code lives in `src/` and is tested with pytest to
 
 3. Run the tests:
 
-   ```bash
-   uv run pytest
-   ```
+```bash
+uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100
+```
 
 ## Dependency management
 
@@ -46,6 +46,15 @@ automatically on each commit:
 pre-commit install
 pre-commit run --all-files  # optional, run on entire repo
 ```
+
+These hooks handle formatting and lightweight checks only. Run Mypy and the
+tests yourself before committing to match the CI pipeline:
+
+```bash
+uv run mypy .
+uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100
+```
+CI will execute the same commands.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary
- remove mypy from pre-commit hooks
- clarify pre-commit vs CI tasks in README
- highlight running mypy and tests manually before commits

## Testing
- `uv run ruff check --fix .`
- `uv run mypy .`
- `uv run pytest --cov=project_name --cov-report=term-missing --cov-fail-under=100`
